### PR TITLE
cdist-build-helper: Make generated versions PEP 440 compliant

### DIFF
--- a/bin/cdist-build-helper
+++ b/bin/cdist-build-helper
@@ -534,12 +534,13 @@ eof
     ;;
 
     version)
-        printf "VERSION = \"%s\"\n" "$(git describe)" > cdist/version.py
+        VERSION=$(git describe --dirty | sed 's/-\([0-9]\{1,\}\)-g\([0-9a-f]\{4,\}\)\(-dirty\)\{0,1\}$/+\2\3/')
+        printf 'VERSION = "%s"\n' "${VERSION}" >cdist/version.py
     ;;
 
     target-version)
         target_version=$($0 changelog-version)
-        printf "VERSION = \"%s\"\n" "${target_version}" > cdist/version.py
+        printf 'VERSION = "%s"\n' "${target_version}" >cdist/version.py
     ;;
 
     clean)


### PR DESCRIPTION
fixes
```
…site-packages/setuptools/dist.py:356: UserWarning: The version specified ('6.9.7-162-g6c0a1585') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
```

by making versions PEP 440 compliant, e.g. `6.9.7+6c0a1585`.

A `-dirty` suffix is added if the repo wasn't clean at version generation time.