### PR TITLE
Silence pip warnings in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Information
         run: |
           python3 -V
-          python3 -m pip list
+          python3 -W ignore -m pip --disable-pip-version-check list
           bin/cdist-build-helper version
           bin/cdist -V
       - name: Build


### PR DESCRIPTION
The deprecation warnings and version checks don't serve any purpose in a CI since we test older versions on purpose.