### PR TITLE
configuration improvements

### DIFF
--- a/skonfig/arguments.py
+++ b/skonfig/arguments.py
@@ -6,6 +6,23 @@ import sys
 _logger = logging.getLogger(__name__)
 
 
+def _set_logging_level(argument_level):
+    levels_pre_py34 = getattr(logging, "_levelNames", {})
+    levels_available = getattr(logging, "_levelToName", levels_pre_py34)
+    levels_used = []
+    for level, level_name in levels_available.items():
+        if not isinstance(level, int):
+            continue
+        if level > logging.getLevelName("INFO"):
+            continue
+        if level_name == "NOTSET":
+            continue
+        levels_used.append(level)
+    levels = list(reversed(sorted(levels_used)))
+    level = levels[min(argument_level, len(levels)-1)]
+    logging.basicConfig(level=level)
+
+
 def get():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -41,8 +58,7 @@ def get():
     )
     parser.add_argument("host", nargs="?", help="host to configure")
     arguments = parser.parse_args()
-    if arguments.verbose >= 2:
-        logging.basicConfig(level=logging.DEBUG)
+    _set_logging_level(arguments.verbose)
     for argument, value in vars(arguments).items():
         _logger.debug("%s: %s", argument, value)
     return parser, arguments

--- a/skonfig/cdist/__init__.py
+++ b/skonfig/cdist/__init__.py
@@ -10,8 +10,12 @@ import cdist.integration
 def run(skonfig_arguments):
     import skonfig.cdist.arguments
     cdist_arguments = skonfig.cdist.arguments.get(skonfig_arguments)
+    if not cdist_arguments:
+        return False
     import skonfig.cdist.configuration
     cdist_configuration = skonfig.cdist.configuration.get(cdist_arguments)
+    if not cdist_configuration:
+        return False
     target_host = cdist_arguments.host[0]
     cdist_config = cdist.config.Config
     cdist_config.construct_remote_exec_copy_patterns(cdist_arguments)

--- a/skonfig/cdist/configuration.py
+++ b/skonfig/cdist/configuration.py
@@ -13,6 +13,8 @@ def get(cdist_arguments):
     )
     import skonfig.configuration
     skonfig_configuration = skonfig.configuration.get()
+    if not skonfig_configuration:
+        return False
     if cdist_arguments.verbose:
         skonfig_configuration["verbosity"] = cdist_arguments.verbose
     for option in skonfig_configuration:

--- a/skonfig/dump.py
+++ b/skonfig/dump.py
@@ -12,8 +12,8 @@ def run(host):
 
 def _get_dumps():
     dumps = {}
-    from skonfig.configuration import CONFIGURATION_DIRECTORY
-    dumps_directory = "{}/dump".format(CONFIGURATION_DIRECTORY)
+    from skonfig.configuration import CONFIGURATION_HOME_PATH
+    dumps_directory = os.path.join(CONFIGURATION_HOME_PATH, "dump")
     if not os.path.isdir(dumps_directory):
         return dumps
     for dump_basename in os.listdir(dumps_directory):


### PR DESCRIPTION
* rename CONFIGURATION_DIRECTORY to CONFIGURATION_HOME_PATH
* added skonfig.arguments._set_logging_level for "smarter" log level
* check if configured conf_dirs exist
* use os.path.join
* print error (and exit) if no conf_dirs
* remove unused import