### PR TITLE
SKONFIG_PATH

### DIFF
--- a/cdist/__init__.py
+++ b/cdist/__init__.py
@@ -241,15 +241,3 @@ def str_hash(s):
         return hashlib.md5(s.encode('utf-8')).hexdigest()
     else:
         raise Error("Param should be string")
-
-
-def home_dir():
-    if 'HOME' in os.environ:
-        home = os.environ['HOME']
-        if home:
-            rv = os.path.join(home, ".skonfig")
-        else:
-            rv = None
-    else:
-        rv = None
-    return rv

--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -158,14 +158,8 @@ class Local:
                        self.object_marker_name, self.object_marker_file)
 
     def _init_cache_dir(self, cache_dir):
-        home_dir = cdist.home_dir()
-        if cache_dir:
-            self.cache_path = cache_dir
-        elif home_dir:
-            self.cache_path = os.path.join(home_dir, "dump")
-        else:
-            raise cdist.Error(
-                "No homedir setup and no cache dir location given")
+        from skonfig.configuration import get_cache_dir
+        self.cache_path = get_cache_dir()
 
     def rmdir(self, path):
         """Remove directory on the local side."""

--- a/cdist/exec/util.py
+++ b/cdist/exec/util.py
@@ -186,19 +186,8 @@ else:
                                                    stdfd.read().decode()))
 
 
-def dist_conf_dir():
-    return os.path.abspath(os.path.join(os.path.dirname(cdist.__file__),
-                                        "conf"))
-
-
 def resolve_conf_dirs(configuration, add_conf_dirs):
     conf_dirs = []
-
-    conf_dirs.append(dist_conf_dir())
-
-    home_dir = cdist.home_dir()
-    if home_dir:
-        conf_dirs.append(home_dir)
 
     if 'conf_dir' in configuration:
         x = configuration['conf_dir']

--- a/cdist/test/exec/local.py
+++ b/cdist/test/exec/local.py
@@ -67,16 +67,10 @@ class LocalTestCase(test.CdistTestCase):
             exec_path=test.cdist_exec_path
         )
 
-        self.home_dir = os.path.join(os.environ['HOME'], ".skonfig")
-
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
 
     # test api
-
-    def test_cache_path(self):
-        self.assertEqual(self.local.cache_path,
-                         os.path.join(self.home_dir, "dump"))
 
     def test_conf_path(self):
         self.assertEqual(self.local.conf_path,

--- a/skonfig/configuration.py
+++ b/skonfig/configuration.py
@@ -4,9 +4,6 @@ import os
 
 _logger = logging.getLogger(__name__)
 
-CONFIGURATION_HOME_PATH = os.path.join(os.getenv("HOME"), ".skonfig")
-CONFIGURATION_FILE_PATH = os.path.join(CONFIGURATION_HOME_PATH, "config")
-
 
 def _set_defaults(configuration):
     configuration["cache_path_pattern"] = "%N"
@@ -20,48 +17,68 @@ def _set_defaults(configuration):
             configuration[option] = defaults[option]
 
 
-def _set_conf_dirs(configuration):
-    # loading order:
-    #   ~/.skonfig/set/
-    #   ~/.skonfig/config:conf_dirs = ...
-    #   ~/.skonfig/
-    if "conf_dir" in configuration:
-        configuration["conf_dir"] = [
-            conf_dir
-            for conf_dir in configuration["conf_dir"].split(os.pathsep)
-            if os.path.isdir(conf_dir)
-        ]
-    else:
-        configuration["conf_dir"] = []
-    if os.path.isdir(CONFIGURATION_HOME_PATH):
-        configuration["conf_dir"].insert(0, CONFIGURATION_HOME_PATH)
-    # find sets and insert them into PATH
-    sets_dir = os.path.join(CONFIGURATION_HOME_PATH, "set")
-    if os.path.isdir(sets_dir):
-        configuration["conf_dir"] += [
-            os.path.join(sets_dir, s) for s in os.listdir(sets_dir)
-        ]
-    configuration["conf_dir"].reverse()
+def _get_search_dirs():
+    pathsep_search_dirs = os.getenv("SKONFIG_PATH", "~/.skonfig:/etc/skonfig")
+    search_dirs = []
+    for search_dir in pathsep_search_dirs.split(":"):
+        search_dir = os.path.expanduser(search_dir)
+        if not os.path.isdir(search_dir):
+            continue
+        search_dirs.append(search_dir)
+    # In cdist "last wins", but from user perspective we want "first wins"
+    # (just like with $PATH). This is also useful in next function,
+    # _set_from_files, where we overwrite previous value(s).
+    search_dirs.reverse()
+    return search_dirs
+
+
+def _set_from_files(configuration):
+    import configparser
+    for search_dir in _get_search_dirs():
+        configuration_file = os.path.join(search_dir, "config")
+        if not os.path.isfile(configuration_file):
+            continue
+        _logger.debug("reading configuration from %s", configuration_file)
+        parser = configparser.RawConfigParser()
+        parser.read(configuration_file)
+        configuration.update(dict(parser.items("skonfig")))
+
+
+def _set_cdist_conf_dir(configuration):
+    # cdist needs "conf_dir" option to function,
+    # but we don't use it, because we have sets.
+    cdist_conf_dir = []
+    search_dirs = _get_search_dirs()
+    for search_dir in search_dirs:
+        sets_dir = os.path.join(search_dir, "set")
+        if os.path.isdir(sets_dir):
+            for set_dir in os.listdir(sets_dir):
+                cdist_conf_dir.append(os.path.join(sets_dir, set_dir))
+        cdist_conf_dir.append(search_dir)
+    configuration["conf_dir"] = cdist_conf_dir
 
 
 def get():
-    if os.path.isfile(CONFIGURATION_FILE_PATH):
-        import configparser
-        parser = configparser.RawConfigParser()
-        parser.read(CONFIGURATION_FILE_PATH)
-        configuration = dict(parser.items("skonfig"))
-    else:
-        configuration = {}
+    configuration = {}
     _set_defaults(configuration)
-    _set_conf_dirs(configuration)
+    _set_from_files(configuration)
+    _set_cdist_conf_dir(configuration)
     if not configuration["conf_dir"]:
-        # since we expect everything is in ~/.skonfig,
-        # then no conf_dirs implies no conf home
-        _logger.error(
-            "no configuration found, %s does not exist",
-            CONFIGURATION_HOME_PATH
-        )
+        _logger.error("no configuration")
         return False
     for option in configuration:
         _logger.debug("%s: %s", option, configuration[option])
     return configuration
+
+
+def get_cache_dir():
+    return os.path.join(
+        os.getenv(
+            "XDG_CACHE_HOME",
+            os.path.join(
+                os.path.expanduser("~"),
+                ".cache"
+            )
+        ),
+        "skonfig"
+    )

--- a/skonfig/dump.py
+++ b/skonfig/dump.py
@@ -12,8 +12,8 @@ def run(host):
 
 def _get_dumps():
     dumps = {}
-    from skonfig.configuration import CONFIGURATION_HOME_PATH
-    dumps_directory = os.path.join(CONFIGURATION_HOME_PATH, "dump")
+    from skonfig.configuration import get_cache_dir
+    dumps_directory = get_cache_dir()
     if not os.path.isdir(dumps_directory):
         return dumps
     for dump_basename in os.listdir(dumps_directory):


### PR DESCRIPTION
Related #49

After long discussion in chat and full stomach from dinner, I arrived to following approach: let's only use `SKONFIG_PATH`, which we use for (`cdist`) `conf_dir`s, and also search for config files and sets.

We should also drop support for `conf_dir` in config file (tho `cdist` codebase still needs it, hence function `_set_cdist_conf_dir`), because it doesn't make sense since we have sets, including change in this PR.

The "problem" with `conf_dir` option: iterate over paths in `SKONFIG_PATH` and search for config files, merge them and what if we see `conf_dir` option from config files? Do we iterate over that too? And what if we find another config files with `conf_dir` and... you get the idea, we can go on forever. `skonfig` will probably not see this kind of (ab)use ever, but having this option feels pointless nevertheless.