### PR TITLE
pass -j to cdist args

### DIFF
--- a/docs/man/man1/skonfig.rst
+++ b/docs/man/man1/skonfig.rst
@@ -20,6 +20,7 @@ SYNOPSIS
       -V          print version
       -d          print dumped hosts, -d <host> = print dump
       -i path     initial manifest or '-' to read from stdin
+      -j jobs     maximum number of jobs (defaults to host CPU count)
       -n          dry-run, do not execute generated code
       -v          -v = VERBOSE, -vv = DEBUG, -vvv = TRACE
 

--- a/skonfig/arguments.py
+++ b/skonfig/arguments.py
@@ -44,6 +44,12 @@ def get():
         help="initial manifest or '-' to read from stdin",
     )
     parser.add_argument(
+        "-j",
+        dest="jobs",
+        metavar="jobs",
+        help="maximum number of jobs (defaults to host CPU count)"
+    )
+    parser.add_argument(
         "-n",
         dest="dry_run",
         action="store_true",

--- a/skonfig/cdist/arguments.py
+++ b/skonfig/cdist/arguments.py
@@ -9,6 +9,13 @@ def get(skonfig_arguments):
     if skonfig_arguments.manifest:
         cdist_argv.append("-i")
         cdist_argv.append(skonfig_arguments.manifest)
+    # how cdist parses -j flag:
+    # no -j = single job
+    # only -j = use cpu count
+    # -j n = n jobs
+    cdist_argv.append("-j")
+    if skonfig_arguments.jobs:
+        cdist_argv.append(skonfig_arguments.jobs)
     if skonfig_arguments.dry_run:
         cdist_argv.append("-n")
     # skonfig default verbosity level is INFO, which in cdist is one -v,


### PR DESCRIPTION
cdist core handles jobs default count bit weirdly:

* no `-j` = single job
* only `-j` = defaults to cpu count
* `-j n` = `n` jobs

But at least we have jobs. And let's use CPU count by default, hence always adding `-j` to cdist args.