### PR TITLE
Actions: run apt-get update before trying to install packages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install make python3 python3-sphinx python3-sphinx-rtd-theme
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install python3 pycodestyle shellcheck
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes the 404 error when trying to install `python3-pil` for the docs pipeline.