### PR TITLE
Remove remote files dirs before cleanup

### DIFF
--- a/cdist/config.py
+++ b/cdist/config.py
@@ -497,8 +497,8 @@ class Config:
             raise cdist.InitialManifestError(self.local.initial_manifest,
                                              stdout_path, stderr_path, e)
         self.iterate_until_finished()
-        self.cleanup()
         self._remove_files_dirs()
+        self.cleanup()
 
         self.local.save_cache(start_time)
         self.log.info("Finished %s run in %.2f seconds",


### PR DESCRIPTION
Just ran across a situation similar to what @fancsali discovered in #52 which could be resolved using this patch.

Reasoning: `cleanup()` closes the SSH mux. If `_remove_files_dirs()` is executed after the mux is closed, SSH will open a new one, going through the whole SSH connection process again.

Swapping `cleanup()` and `_remove_files_dirs()` will make `_remove_files_dirs()` use the already open mux before it is closed.

On a host with no pubkey authentication configured:

Before:
```console
$ echo __cdistmarker | skonfig -i- 172.16.167.232
INFO: svn.vm: Starting configuration run
root@172.16.167.232's password:
INFO: svn.vm: Processing __cdistmarker/
root@172.16.167.232's password:
INFO: svn.vm: Finished successful run in 5.98 seconds
```

After:
```console
$ echo __cdistmarker | skonfig -i- 172.16.167.232
INFO: svn.vm: Starting configuration run
root@172.16.167.232's password:
INFO: svn.vm: Processing __cdistmarker/
INFO: svn.vm: Finished successful run in 4.24 seconds
```