### PR TITLE
Add option to disable archiving

### DIFF
--- a/bin/cdist
+++ b/bin/cdist
@@ -99,7 +99,7 @@ def _commandline():
     # FIXME: we always print main help, not
     # the help of the actual parser being used!
     try:
-        getattr(args, "func")
+        getattr(args, "cls")
     except AttributeError:
         parser['main'].print_help()
         sys.exit(0)
@@ -107,7 +107,7 @@ def _commandline():
     if cfg.get_config(section="GLOBAL").get("check_python_version", True):
         _check_python_version()
 
-    args.func(args)
+    args.cls.commandline(args)
 
 
 if __name__ == "__main__":

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -1,9 +1,10 @@
 import argparse
-import cdist
-import multiprocessing
-import logging
 import collections
 import functools
+import logging
+import multiprocessing
+
+import cdist
 import cdist.config
 import cdist.configuration
 import cdist.log
@@ -160,11 +161,12 @@ def get_parsers():
            action='store_true', dest='timestamp')
     parser['config_main'].add_argument(
            '-R', '--use-archiving', nargs='?',
-           choices=('tar', 'tgz', 'tbz2', 'txz',),
+           choices=cdist.autil.archiving_values.keys(),
            help=('Operate by using archiving with compression where '
-                 'appropriate. Supported values are: tar - tar archive, '
-                 'tgz - gzip tar archive (the default), '
-                 'tbz2 - bzip2 tar archive and txz - lzma tar archive. '),
+                 'appropriate. Supported values are: '
+                 + ", ".join(
+                     "%s - %s" % (name, doc)
+                     for (name, doc) in cdist.autil.archiving_values.items())),
            action='store', dest='use_archiving',
            const='tgz')
 

--- a/cdist/argparse.py
+++ b/cdist/argparse.py
@@ -222,7 +222,7 @@ def get_parsers():
                                parser['common'],
                                parser['config_main'],
                                parser['config_args']])
-    parser['config'].set_defaults(func=cdist.config.Config.commandline)
+    parser['config'].set_defaults(cls=cdist.config.Config)
 
     return parser
 

--- a/cdist/autil.py
+++ b/cdist/autil.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # 2017 Darko Poljak (darko.poljak at gmail.com)
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of cdist.
 #
@@ -19,49 +20,100 @@
 #
 #
 
-
-import cdist
-import tarfile
-import os
 import glob
+import os
+import tarfile
 import tempfile
 
 
-_ARCHIVING_MODES = {
-    'tar': '',
-    'tgz': 'gz',
-    'tbz2': 'bz2',
-    'txz': 'xz',
-}
+class ArchivingMode:
+    @classmethod
+    def is_supported(cls):
+        if cls.tarmode:
+            return cls.tarmode in tarfile.TarFile.OPEN_METH
+        else:
+            # plain tar is always supported
+            return True
+
+    @classmethod
+    def name(cls):
+        return cls.__name__.lower()
+
+    @classmethod
+    def doc(cls):
+        return cls.__doc__
 
 
-_UNARCHIVE_OPT = {
-    'tar': None,
-    'tgz': '-z',
-    'tbz2': '-j',
-    'txz': '-J',
-}
+class TAR(ArchivingMode):
+    "tar archive"
+    tarmode = ""
+    file_ext = ".tar"
+    extract_opts = []
+
+
+class TGZ(ArchivingMode):
+    "gzip tar archive"
+    tarmode = "gz"
+    file_ext = ".tar.gz"
+    extract_opts = ["-z"]
+
+
+class TBZ2(ArchivingMode):
+    "bzip2 tar archive"
+    tarmode = "bz2"
+    file_ext = ".tar.bz2"
+    extract_opts = ["-j"]
+
+
+class TXZ(ArchivingMode):
+    "lzma tar archive"
+    tarmode = "xz"
+    file_ext = ".tar.xz"
+    extract_opts = ["-J"]
+
+
+archiving_modes = [TAR, TGZ, TBZ2, TXZ]
+
+# for CLI or config
+archiving_values = dict(
+    none="no archiving",
+    **{m.name(): m.doc() for m in archiving_modes})
+
+
+def mode_from_str(s):
+    s_lc = s.lower()
+
+    if s_lc == "none":
+        # special case to disable the archiving feature
+        return None
+
+    for mode in archiving_modes:
+        if (mode.name() == s_lc):
+            break
+    else:
+        raise ValueError("invalid archiving mode: %s" % s)
+
+    # check if the method is supported by this python version
+    if not mode.is_supported():
+        raise RuntimeError(
+            "the archiving mode '%s' is not supported by this version of "
+            "Python" % (mode.name()))
+
+    return mode
 
 
 # Archiving will be enabled if directory contains more than FILES_LIMIT files.
 FILES_LIMIT = 1
 
 
-def get_extract_option(mode):
-    return _UNARCHIVE_OPT[mode]
-
-
-def tar(source, mode="tgz"):
-    if mode not in _ARCHIVING_MODES:
-        raise cdist.Error("Unsupported archiving mode {}.".format(mode))
-
+def tar(source, mode=TGZ):
     files = glob.glob1(source, '*')
     fcnt = len(files)
     if fcnt <= FILES_LIMIT:
         return None, fcnt
 
-    tarmode = 'w:{}'.format(_ARCHIVING_MODES[mode])
-    _, tarpath = tempfile.mkstemp(suffix='.' + mode)
+    tarmode = "w:%s" % mode.tarmode
+    _, tarpath = tempfile.mkstemp(suffix=mode.file_ext)
     with tarfile.open(tarpath, tarmode, dereference=True) as tar:
         if os.path.isdir(source):
             for f in files:

--- a/cdist/config.py
+++ b/cdist/config.py
@@ -32,11 +32,12 @@ import atexit
 import shutil
 import socket
 
-from cdist.mputil import mp_pool_run, mp_sig_handler
 from cdist import core
+from cdist.mputil import mp_pool_run, mp_sig_handler
 from cdist.util.remoteutil import inspect_ssh_mux_opts
 
 import cdist
+import cdist.autil
 import cdist.hostsource
 import cdist.exec.local
 import cdist.exec.remote
@@ -388,7 +389,7 @@ class Config:
                 remote_copy=remote_copy,
                 base_path=args.remote_out_path,
                 quiet_mode=args.quiet,
-                archiving_mode=args.use_archiving,
+                archiving_mode=cdist.autil.mode_from_str(args.use_archiving),
                 configuration=configuration,
                 stdout_base_path=local.stdout_base_path,
                 stderr_base_path=local.stderr_base_path,

--- a/cdist/configuration.py
+++ b/cdist/configuration.py
@@ -21,13 +21,15 @@
 
 
 import configparser
+import logging
+import multiprocessing
 import os
+import re
+import sys
+
 import cdist
 import cdist.argparse
-import re
-import multiprocessing
-import logging
-import sys
+import cdist.autil
 
 
 class Singleton(type):
@@ -44,9 +46,6 @@ class Singleton(type):
 
 _VERBOSITY_VALUES = (
     'ERROR', 'WARNING', 'INFO', 'VERBOSE', 'DEBUG', 'TRACE', 'OFF',
-)
-_ARCHIVING_VALUES = (
-    'tar', 'tgz', 'tbz2', 'txz', 'none',
 )
 
 
@@ -220,13 +219,11 @@ class ConfDirOption(DelimitedValuesOption):
 
 class ArchivingOption(SelectOption):
     def __init__(self):
-        super().__init__('archiving', _ARCHIVING_VALUES)
+        super().__init__('archiving', cdist.autil.archiving_values)
 
     def translate(self, val):
-        if val == 'none':
-            return None
-        else:
-            return val
+        mode = cdist.autil.mode_from_str(val)
+        return mode.name() if mode is not None else None
 
 
 class LogLevelOption(OptionBase):
@@ -306,9 +303,6 @@ class Configuration(metaclass=Singleton):
     default_config_files = (_global_config_file, _dist_config_file,
                             _local_config_file, )
     ENV_VAR_CONFIG_FILE = 'CDIST_CONFIG_FILE'
-
-    VERBOSITY_VALUES = _VERBOSITY_VALUES
-    ARCHIVING_VALUES = _ARCHIVING_VALUES
 
     CONFIG_FILE_OPTIONS = {
         'GLOBAL': {

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -319,7 +319,14 @@ class Remote:
 
             return output
         except (OSError, subprocess.CalledProcessError) as error:
-            raise cdist.Error(" ".join(command) + ": " + str(error.args[1]))
+            emsg = ""
+            if not isinstance(command, (str, bytes)):
+                emsg += " ".join(command)
+            else:
+                emsg += command
+            if error.args:
+                emsg += ": " + str(error.args[1])
+            raise cdist.Error(emsg)
         except UnicodeDecodeError:
             raise DecodeError(command)
         finally:

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -144,14 +144,14 @@ class Remote:
         import cdist.autil as autil
 
         self.log.trace("Remote extract archive: %s", path)
-        command = ["tar", "-x", "-m", "-C", ]
-        directory = os.path.dirname(path)
-        command.append(directory)
-        xopt = autil.get_extract_option(mode)
-        if xopt:
-            command.append(xopt)
-        command.append("-f")
-        command.append(path)
+        command = [
+            "tar",
+            "-C", os.path.dirname(path),
+            "-x",
+            "-f", path
+        ]
+        if mode is not None:
+            command += mode.extract_opts
         self.run(command)
 
     def _transfer_file(self, source, destination):
@@ -167,7 +167,7 @@ class Remote:
         if os.path.isdir(source):
             self.mkdir(destination)
             used_archiving = False
-            if self.archiving_mode:
+            if self.archiving_mode is not None:
                 self.log.trace("Remote transfer in archiving mode")
                 import cdist.autil as autil
 

--- a/cdist/hostsource.py
+++ b/cdist/hostsource.py
@@ -59,7 +59,7 @@ class HostSource:
 
     def hosts(self):
         if not self.source:
-            return
+            return iter(())
 
         if isinstance(self.source, str):
             return self._hosts_from_file()

--- a/cdist/log.py
+++ b/cdist/log.py
@@ -39,7 +39,7 @@ logging.addLevelName(logging.VERBOSE, 'VERBOSE')
 
 
 def _verbose(self, msg, *args, **kwargs):
-    self.log(logging.VERBOSE, msg, args, **kwargs)
+    self.log(logging.VERBOSE, msg, *args, **kwargs)
 
 
 logging.Logger.verbose = _verbose

--- a/cdist/test/autil/__init__.py
+++ b/cdist/test/autil/__init__.py
@@ -19,12 +19,13 @@
 #
 #
 
-from cdist import test
-import cdist.autil as autil
 import os
 import os.path as op
 import tarfile
 
+import cdist.autil
+
+from cdist import test
 
 my_dir = op.abspath(op.dirname(__file__))
 fixtures = op.join(my_dir, 'fixtures')
@@ -33,19 +34,13 @@ explorers_path = op.join(fixtures, 'explorer')
 
 class AUtilTestCase(test.CdistTestCase):
     def test_tar(self):
-        test_modes = {
-            'tar': 'r:',
-            'tgz': 'r:gz',
-            'tbz2': 'r:bz2',
-            'txz': 'r:xz',
-        }
         source = explorers_path
-        for mode in test_modes:
+        for mode in cdist.autil.archiving_modes:
             try:
-                tarpath, fcnt = autil.tar(source, mode)
+                tarpath, fcnt = cdist.autil.tar(source, mode)
                 self.assertIsNotNone(tarpath)
                 fcnt = 0
-                with tarfile.open(tarpath, test_modes[mode]) as tar:
+                with tarfile.open(tarpath, "r:" + mode.tarmode) as tar:
                     for tarinfo in tar:
                         fcnt += 1
                 os.remove(tarpath)


### PR DESCRIPTION
In skonfig the archiving is enabled by default, unlike in cdist.
No option is provided to disable the feature should the target be incompatible with archiving.
This patch adds a `archiving = none` option to be added to `~/.skonfig/config` to disable the feature.

Also, for the legacy cdist(1) interface, `cdist config -R none` is now supported.

The `tar -m` option is not supported (at least) by BusyBox tar(1) on OpenWrt.
Since I don't know about any location in skonfig where file modification times matter, I dropped the -m option for compatibility.

While at it I also patched some other minor errors I stumbled over.