### PR TITLE
CI: update versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install make python3 python3-sphinx python3-sphinx-rtd-theme
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Information

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install python3 pycodestyle shellcheck
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Information

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -10,20 +10,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu
+          - macos
+        python-version:
+          - pypy-3.6
+          - pypy-3.7
+          - pypy-3.8
+          - pypy-3.9
         include:
-          - {os: "ubuntu-18.04",  python-version: "3.3"}
-          - {os: "ubuntu-18.04",  python-version: "3.4"}
-          - {os: "ubuntu-18.04",  python-version: "3.5"}
-          - {os: "ubuntu-18.04",  python-version: "3.6"}
-          - {os: "ubuntu-18.04",  python-version: "pypy-3.6"}
-          - {os: "ubuntu-18.04",  python-version: "pypy-3.7"}
-          - {os: "ubuntu-latest", python-version: "pypy-3.8"}
-          - {os: "ubuntu-latest", python-version: "pypy-3.9"}
-          - {os: "macos-latest",  python-version: "3.5"}
-          - {os: "macos-latest",  python-version: "3.6"}
-          - {os: "macos-latest",  python-version: "pypy-3.8"}
-          - {os: "macos-latest",  python-version: "pypy-3.9"}
-    runs-on: ${{ matrix.os }}
+          - {os: "macos",  python-version: "3.5"}
+          - {os: "macos",  python-version: "3.6"}
+        exclude:
+          - {os: "macos",  python-version: "pypy-3.6"}
+          - {os: "macos",  python-version: "pypy-3.9"}
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Information

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -10,9 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-    runs-on: ${{ matrix.os }}
+        os:
+          - ubuntu
+          - macos
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -22,6 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
+          allow-prereleases: true
           python-version: ${{ matrix.python-version }}
       - name: Information
         run: |

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -10,20 +10,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu
+          - macos
+        python-version:
+          - pypy-3.6
+          - pypy-3.7
+          - pypy-3.8
+          - pypy-3.9
         include:
-          - {os: "ubuntu-18.04",  python-version: "3.3"}
-          - {os: "ubuntu-18.04",  python-version: "3.4"}
-          - {os: "ubuntu-18.04",  python-version: "3.5"}
-          - {os: "ubuntu-18.04",  python-version: "3.6"}
-          - {os: "ubuntu-18.04",  python-version: "pypy-3.6"}
-          - {os: "ubuntu-18.04",  python-version: "pypy-3.7"}
-          - {os: "ubuntu-latest", python-version: "pypy-3.8"}
-          - {os: "ubuntu-latest", python-version: "pypy-3.9"}
-          - {os: "macos-latest",  python-version: "3.5"}
-          - {os: "macos-latest",  python-version: "3.6"}
-          - {os: "macos-latest",  python-version: "pypy-3.8"}
-          - {os: "macos-latest",  python-version: "pypy-3.9"}
-    runs-on: ${{ matrix.os }}
+          - {os: "macos",  python-version: "3.5"}
+          - {os: "macos",  python-version: "3.6"}
+        exclude:
+          - {os: "macos",  python-version: "pypy-3.6"}
+          - {os: "macos",  python-version: "pypy-3.9"}
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Information

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -10,9 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-    runs-on: ${{ matrix.os }}
+        os:
+          - ubuntu
+          - macos
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -22,6 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
+          allow-prereleases: true
           python-version: ${{ matrix.python-version }}
       - name: Information
         run: |

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Changes to GitHub Actions:
- remove `-latest` from job names (they are all `-latest`),
- remove jobs running on Ubuntu 18.04,
- update action versions to fix Node 12 error,
- run tests on Python 3.12 (pre-release).