### PR TITLE
Safer quoting of shell commands

### DIFF
--- a/cdist/config.py
+++ b/cdist/config.py
@@ -34,6 +34,7 @@ import socket
 
 from cdist import core
 from cdist.mputil import mp_pool_run, mp_sig_handler
+from cdist.util import shquot
 from cdist.util.remoteutil import inspect_ssh_mux_opts
 
 import cdist
@@ -460,13 +461,9 @@ class Config:
     def cleanup(self):
         self.log.debug("Running cleanup commands")
         for cleanup_cmd in self.cleanup_cmds:
-            cmd = cleanup_cmd.split()
-            cmd.append(self.local.target_host[0])
+            cmd = shquot.split(cleanup_cmd) + [self.local.target_host[0]]
             try:
-                if self.log.getEffectiveLevel() <= logging.DEBUG:
-                    quiet_mode = False
-                else:
-                    quiet_mode = True
+                quiet_mode = self.log.getEffectiveLevel() > logging.DEBUG
                 self.local.run(cmd, return_output=False, save_output=False,
                                quiet_mode=quiet_mode)
             except cdist.Error as e:

--- a/cdist/core/explorer.py
+++ b/cdist/core/explorer.py
@@ -20,11 +20,13 @@
 #
 #
 
-import logging
-import os
 import glob
+import logging
 import multiprocessing
+import os
+
 import cdist
+import cdist.util.shquot as shquot
 from cdist.mputil import mp_pool_run
 from . import util
 
@@ -167,8 +169,8 @@ class Explorer:
             self.remote.transfer(self.local.global_explorer_path,
                                  self.remote.global_explorer_path,
                                  self.jobs)
-            self.remote.run(["chmod", "0700", "{}/*".format(
-                self.remote.global_explorer_path)])
+            self.remote.run("chmod 0700 %s/*" % (
+                shquot.quote(self.remote.global_explorer_path)))
 
     def run_global_explorer(self, explorer):
         """Run the given global explorer and return it's output."""
@@ -249,7 +251,8 @@ class Explorer:
                 destination = os.path.join(self.remote.type_path,
                                            cdist_type.explorer_path)
                 self.remote.transfer(source, destination)
-                self.remote.run(["chmod", "0700", "{}/*".format(destination)])
+                self.remote.run("chmod 0700 %s/*" % (
+                    shquot.quote(destination)))
                 self._type_explorers_transferred.append(cdist_type.name)
 
     def transfer_object_parameters(self, cdist_object):

--- a/cdist/util/shquot.py
+++ b/cdist/util/shquot.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import re
+import shlex
+
+_needs_shell_quoting = re.compile(r"[^\w@%+=:,./-]", re.ASCII).search
+
+
+def join(cmd_args):
+    return " ".join(map(quote, cmd_args))
+
+
+def quote(s):
+    """Return a shell-escaped version of the string *s*."""
+    if not s:
+        return "''"
+    if _needs_shell_quoting(s) is not None:
+        s = "'" + (s.replace("'", r"'\''")) + "'"
+
+    return s
+
+
+def split(s):
+    return shlex.split(s)


### PR DESCRIPTION
Currently the components of the `command` list were just concatented using `" "` no matter its contents.

This PR tries to address this by quoting the parts of the command which need to be quoted.