### PR TITLE
setup.py: make compatible with Python 3.12

### DIFF
--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -18,6 +18,7 @@ jobs:
           - pypy-3.7
           - pypy-3.8
           - pypy-3.9
+          - pypy-3.10
         include:
           - {os: "macos",  python-version: "3.5"}
           - {os: "macos",  python-version: "3.6"}

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -27,7 +27,6 @@ jobs:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}
       - name: Install setuptools
-        if: ${{ (0+matrix.python-version) >= 3.12 }}
         run: |
           pip install setuptools
       - name: Information

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -27,7 +27,7 @@ jobs:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}
       - name: Install setuptools
-        if: ${{ matrix.python-version >= 3.12 }}
+        if: ${{ (0+matrix.python-version) >= 3.12 }}
         run: |
           pip install setuptools
       - name: Information

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}
+      - name: Install setuptools
+        if: ${{ matrix.python-version >= 3.12 }}
+        run: |
+          pip install setuptools
       - name: Information
         run: |
           python3 -V

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ incubator for new types.
 pip3 install skonfig@git+https://github.com/skonfig/skonfig
 ```
 
+Note: if you run Python 3.12 or later, you need to have
+[setuptools](https://setuptools.pypa.io/) installed.
+
 ### Step 2: Clone sets repositories
 
 Clone the sets you are planning to use. To get started installing the `base` and


### PR DESCRIPTION
On Python 3.12 the installation of setuptools is now required.