### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install make python3 python3-sphinx python3-sphinx-rtd-theme
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Information
@@ -30,7 +30,7 @@ jobs:
           make docs
       - name: Archive docs
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: |
             docs/dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install python3 pycodestyle shellcheck
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Information

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Information

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
+          - ubuntu-latest
+          - macos-13
         python-version:
           - pypy-3.6
           - pypy-3.7
@@ -23,12 +23,8 @@ jobs:
           - graalpy-23.1.2
           - graalpy-24.1.1
         include:
-          - {os: "macos",  python-version: "3.5"}
-          - {os: "macos",  python-version: "3.6"}
-        exclude:
-          - {os: "macos",  python-version: "pypy-3.6"}
-          - {os: "macos",  python-version: "pypy-3.9"}
-    runs-on: ${{ matrix.os }}-latest
+          - {os: "macos-13", python-version: "3.6"}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -19,6 +19,9 @@ jobs:
           - pypy-3.8
           - pypy-3.9
           - pypy-3.10
+          - graalpy-22.3.1
+          - graalpy-23.1.2
+          - graalpy-24.1.1
         include:
           - {os: "macos",  python-version: "3.5"}
           - {os: "macos",  python-version: "3.6"}

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu
           - macos
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -14,6 +14,8 @@ jobs:
           - ubuntu
           - macos
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - {os: "macos", python-version: "3.7"}
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
+          - ubuntu-latest
+          - macos-13
         python-version:
           - pypy-3.6
           - pypy-3.7
@@ -22,12 +22,8 @@ jobs:
           - graalpy-23.1.2
           - graalpy-24.1.1
         include:
-          - {os: "macos",  python-version: "3.5"}
-          - {os: "macos",  python-version: "3.6"}
-        exclude:
-          - {os: "macos",  python-version: "pypy-3.6"}
-          - {os: "macos",  python-version: "pypy-3.9"}
-    runs-on: ${{ matrix.os }}-latest
+          - {os: "macos-13", python-version: "3.6"}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Information

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -18,6 +18,9 @@ jobs:
           - pypy-3.7
           - pypy-3.8
           - pypy-3.9
+          - graalpy-22.3.1
+          - graalpy-23.1.2
+          - graalpy-24.1.1
         include:
           - {os: "macos",  python-version: "3.5"}
           - {os: "macos",  python-version: "3.6"}

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu
           - macos
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -14,6 +14,8 @@ jobs:
           - ubuntu
           - macos
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - {os: "macos", python-version: "3.7"}
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code


### PR DESCRIPTION
- added Python 3.13 to CI
- added GraalVM to CI
- revert to Intel-based macOS runners for optional tests (because not all Python versions have arm64 versions available)
- update GitHub actions to latest versions