### PR TITLE
pass cdist errors because cdist prints its own errors

### DIFF
--- a/skonfig/__init__.py
+++ b/skonfig/__init__.py
@@ -8,9 +8,13 @@ THIS_IS_SKONFIG = False
 
 
 def run():
+    import cdist
     import skonfig.cdist
     if os.path.basename(sys.argv[0])[:2] == "__":
-        return skonfig.cdist.emulator()
+        try:
+            return skonfig.cdist.emulator()
+        except cdist.Error:
+            pass
     import skonfig.arguments
     parser, arguments = skonfig.arguments.get()
     if arguments.version:
@@ -22,4 +26,7 @@ def run():
     if arguments.dump:
         import skonfig.dump
         return skonfig.dump.run(arguments.host)
-    return skonfig.cdist.run(arguments)
+    try:
+        return skonfig.cdist.run(arguments)
+    except cdist.Error:
+        pass


### PR DESCRIPTION
Let's bump the last modified date, otherwise people might think this is a dead project :smirk: 

I finally got annoyed with long Python traces when some object misbehaves.

Since the cdist code already [handles errors with pretty printing](https://github.com/skonfig/skonfig/blob/main/cdist/__init__.py#L113), let's just pass them.