### PR TITLE
type manifest can be dir of manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You can find us in `#skonfig:matrix.org` ([matrix?](https://matrix.org/faq/)).
 Most parts of [cdist documentation](https://www.cdi.st/manual/latest/) apply, but there are differences:
 
 * `skonfig` does only `config` (see `skonfig -h`),
+* types are managed in sets,
+* type manifest can be directory of manifests,
 * some types behave differently and it's recommended to consult manuals in *base* and *extra*.
 
 ## Split between *base* and *extra*

--- a/cdist/core/manifest.py
+++ b/cdist/core/manifest.py
@@ -200,9 +200,21 @@ class Manifest:
     def run_type_manifest(self, cdist_object):
         type_manifest = os.path.join(self.local.type_path,
                                      cdist_object.cdist_type.manifest_path)
+        type_init_manifest = os.path.join(type_manifest, "init")
+        if os.path.isfile(type_init_manifest):
+            type_manifests = [type_init_manifest]
+        elif os.path.isdir(type_manifest):
+            type_manifests = []
+            for m in os.listdir(type_manifest):
+                type_manifests.append(os.path.join(type_manifest, m))
+            type_manifests.sort()
+        elif os.path.isfile(type_manifest):
+            type_manifests = [type_manifest]
+        else:
+            return
         message_prefix = cdist_object.name
         which = 'manifest'
-        if os.path.isfile(type_manifest):
+        for type_manifest in type_manifests:
             self.log.verbose("Running type manifest %s for object %s",
                              type_manifest, cdist_object.name)
             if self.local.save_output_streams:


### PR DESCRIPTION
All my stuff is organized around types and some types have very long manifest (~500 lines). Sure, split it up, you say, but same time having this small simple way to split up manifest into smaller manifests makes life little easier. Everything seems to work as is, with no breakage (let's see what tests do, hehe), but what do you think, @sideeffect42?

In logs:
```
VERBOSE: media.internal: Preparing object __host_media/
VERBOSE: media.internal: Running manifest and explorers for __host_media/
VERBOSE: media.internal: Running type explorers for <CdistType __host_media
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/base for object __host_media/
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/funny for object __host_media/
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/isofiles for object __host_media/
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/nginx for object __host_media/
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/samba for object __host_media/
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/srv for object __host_media/
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/wh40k for object __host_media/
VERBOSE: media.internal: Running type manifest /tmp/tmp2ms_u4n5/0480c6f84cb1b9543f0cd34655244113/data/conf/type/__host_media/manifest/yarr for object __host_media/
```