### PR TITLE
Fixup #92: restore set resolution logic

### DIFF
--- a/cdist/config.py
+++ b/cdist/config.py
@@ -24,19 +24,14 @@
 import os
 import sys
 import time
-import itertools
 import tempfile
 import multiprocessing
-import atexit
 import shutil
-import socket
 
 import cdist
-import cdist.autil
 import cdist.exec.local
 import cdist.exec.remote
 import cdist.log
-import cdist.util
 
 from cdist.exec.util import get_std_fd
 from cdist.mputil import (mp_pool_run, mp_sig_handler)

--- a/cdist/core/explorer.py
+++ b/cdist/core/explorer.py
@@ -138,13 +138,14 @@ class Explorer:
             self.log.trace(
                 "Multiprocessing start method is %s",
                 multiprocessing.get_start_method())
-        self.log.trace(
-            "Starting multiprocessing Pool for global explorers run")
-        args = [
-            (e, out_path, ) for e in self.list_global_explorer_names()
-        ]
-        mp_pool_run(self._run_global_explorer, args, jobs=self.jobs)
-        self.log.trace("Multiprocessing run for global explorers finished")
+
+        global_explorers = self.list_global_explorer_names()
+        if global_explorers:
+            self.log.trace(
+                "Starting multiprocessing Pool for global explorers run")
+            args = [(e, out_path) for e in global_explorers]
+            mp_pool_run(self._run_global_explorer, args, jobs=self.jobs)
+            self.log.trace("Multiprocessing run for global explorers finished")
 
     # logger is not pickable, so remove it when we pickle
     def __getstate__(self):

--- a/cdist/mputil.py
+++ b/cdist/mputil.py
@@ -27,6 +27,7 @@ import signal
 
 import cdist.log
 
+default_jobs = min(4, multiprocessing.cpu_count())
 log = cdist.log.getLogger("cdist-mputil")
 
 
@@ -39,7 +40,7 @@ def _mp_run_method(self, fname, *args, **kwargs):
     return getattr(self, fname)(*args, **kwargs)
 
 
-def mp_pool_run(func, args=None, kwds=None, jobs=multiprocessing.cpu_count()):
+def mp_pool_run(func, args=None, kwds=None, jobs=default_jobs):
     """Run func using concurrent.futures.ProcessPoolExecutor with jobs jobs
     and supplied iterables of args and kwds with one entry for each
     parallel func instance.

--- a/cdist/test/settings/__init__.py
+++ b/cdist/test/settings/__init__.py
@@ -211,6 +211,31 @@ class SearchPathSettingTestCase(test.CdistTestCase):
 
             self.assertEqual(self.path_setting, [init_value])
 
+    def test_can_use_list_manipulation_operators(self):
+        self.path_setting = ["/bin"]
+        self.assertEqual(self.path_setting, ["/bin"])
+
+        self.path_setting.insert(0, "/sbin")
+        self.assertEqual(self.path_setting, ["/sbin", "/bin"])
+
+        self.path_setting += ["/usr/sbin", "/usr/bin"]
+        self.assertEqual(self.path_setting, [
+            "/sbin", "/bin",
+            "/usr/sbin", "/usr/bin"])
+
+        self.path_setting.extend(["/usr/local/sbin", "/usr/local/bin"])
+        self.assertEqual(self.path_setting, [
+            "/sbin", "/bin",
+            "/usr/sbin", "/usr/bin",
+            "/usr/local/sbin", "/usr/local/bin"])
+
+        self.path_setting.append("/opt/bin")
+        self.assertEqual(self.path_setting, [
+            "/sbin", "/bin",
+            "/usr/sbin", "/usr/bin",
+            "/usr/local/sbin", "/usr/local/bin",
+            "/opt/bin"])
+
 
 class FileSettingTestCase(test.CdistTestCase):
     existing_file = os.path.join(fixtures, "somefile.txt")

--- a/skonfig/cdist.py
+++ b/skonfig/cdist.py
@@ -1,6 +1,9 @@
+import atexit
 import logging
+import os
 import shutil
 import sys
+import tempfile
 
 import cdist.log
 import skonfig.settings
@@ -16,6 +19,19 @@ def _initialise_global_settings():
 
     # read values from environment variables
     settings.update_from_env()
+
+    # resolve sets
+    search_dirs = skonfig.settings.get_config_search_dirs()
+    for search_dir in search_dirs:
+        sets_dir = os.path.join(search_dir, "set")
+        if os.path.isdir(sets_dir):
+            settings.conf_dir += [
+                os.path.join(sets_dir, set_dir)
+                for set_dir in os.listdir(sets_dir)
+                if os.path.isdir(os.path.join(sets_dir, set_dir))]
+
+    # because last one wins
+    settings.conf_dir += search_dirs
 
     return settings
 

--- a/skonfig/dump.py
+++ b/skonfig/dump.py
@@ -12,7 +12,7 @@ def run(host):
 
 def _get_dumps():
     dumps = {}
-    from skonfig.configuration import get_cache_dir
+    from skonfig.settings import get_cache_dir
     dumps_directory = get_cache_dir()
     if not os.path.isdir(dumps_directory):
         return dumps


### PR DESCRIPTION
The set resolution logic was inadvertently removed with the introduction of `skonfig.settings`.
*insert ashamed emoji here*

At the same time another bug in `cdist.core.explorer` was uncovered.
When no explorers are detected, the `mptuil` still tries to run "no explorers" which messes up the function arguments.