### PR TITLE
Require only readability of initial manifest

### DIFF
--- a/cdist/core/manifest.py
+++ b/cdist/core/manifest.py
@@ -161,7 +161,7 @@ class Manifest:
         else:
             user_supplied = True
 
-        if not os.path.isfile(initial_manifest):
+        if not os.access(initial_manifest, os.R_OK):
             raise NoInitialManifestError(initial_manifest, user_supplied)
 
         message_prefix = "initialmanifest"


### PR DESCRIPTION
It does not necessarily have to be a file, since we also allow stdin.

This also allows usage of `/dev/null` as the initial manifest.
So, to just query basic system information it is now possible to run:

    skonfig -i /dev/null host.example.com && skonfig -d host.example.com