### PR TITLE
make tar more compatible

### DIFF
--- a/cdist/autil.py
+++ b/cdist/autil.py
@@ -48,28 +48,28 @@ class TAR(ArchivingMode):
     "tar archive"
     tarmode = ""
     file_ext = ".tar"
-    extract_opts = []
+    extract_opts = ""
 
 
 class TGZ(ArchivingMode):
     "gzip tar archive"
     tarmode = "gz"
     file_ext = ".tar.gz"
-    extract_opts = ["-z"]
+    extract_opts = "z"
 
 
 class TBZ2(ArchivingMode):
     "bzip2 tar archive"
     tarmode = "bz2"
     file_ext = ".tar.bz2"
-    extract_opts = ["-j"]
+    extract_opts = "j"
 
 
 class TXZ(ArchivingMode):
     "lzma tar archive"
     tarmode = "xz"
     file_ext = ".tar.xz"
-    extract_opts = ["-J"]
+    extract_opts = "J"
 
 
 archiving_modes = [TAR, TGZ, TBZ2, TXZ]
@@ -112,7 +112,12 @@ def tar(source, mode=TGZ):
 
     tarmode = "w:%s" % (mode.tarmode)
     (_, tarpath) = tempfile.mkstemp(suffix=mode.file_ext)
-    with tarfile.open(tarpath, tarmode, dereference=True) as tar:
+    with tarfile.open(
+        tarpath,
+        tarmode,
+        dereference=True,
+        format=tarfile.USTAR_FORMAT
+    ) as tar:
         if os.path.isdir(source):
             for f in files:
                 tar.add(os.path.join(source, f), arcname=f)

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -137,15 +137,14 @@ class Remote:
         import cdist.autil as autil
 
         self.log.trace("Remote extract archive: %s", path)
-        # AIX only allows -C at the end
-        command = [
-            "tar",
-            "-x",
-            "-f", path,
-            "-C", os.path.dirname(path)
-        ]
+        opts = "x"
         if mode is not None:
-            command += mode.extract_opts
+            opts += mode.extract_opts
+        # for maximum compatibility, the filename must immediately follow f
+        command = "cd {} && tar {}f {}".format(
+            shquot.quote(os.path.dirname(path)),
+            opts,
+            shquot.quote("./" + os.path.basename(path)))
         self.run(command)
 
     def _transfer_file(self, source, destination, umask=None):


### PR DESCRIPTION
Omnios don't know anything about `-x -f` and is not capable extracting PAX format (default since Python 3.8).
GNU Tar produces archive that tastes well enough. More compatible would be POSIX.1-1988 (ustar) format.
This explains why I didn't have any issue when doing https://github.com/skonfig/base/commit/8ace47cf91c90bd52f978c9af7df61a71e7aac62. Or we didn't have archiving yet then? :thinking: 

But do we know if `xf` is compatible enough with most stuff?