### PR TITLE
Print executed commands always in shell quoted form

### DIFF
--- a/cdist/exec/local.py
+++ b/cdist/exec/local.py
@@ -37,6 +37,8 @@ import cdist.message
 
 import cdist.exec.util as util
 
+from cdist.util import shquot
+
 CONF_SUBDIRS_LINKED = ["explorer", "files", "manifest", "type"]
 
 
@@ -186,7 +188,7 @@ class Local:
             message = cdist.message.Message(message_prefix, self.messages_path)
             env.update(message.env)
 
-        self.log.trace("Local run: %s", command)
+        self.log.trace("Local run: %s", shquot.join(command))
         try:
             if return_output:
                 result = subprocess.check_output(

--- a/cdist/exec/remote.py
+++ b/cdist/exec/remote.py
@@ -299,7 +299,7 @@ class Remote:
         os_environ['__target_hostname'] = self.target_host[1]
         os_environ['__target_fqdn'] = self.target_host[2]
 
-        self.log.trace("Remote run: %s", command)
+        self.log.trace("Remote run: %s", shquot.join(command))
         try:
             if return_output:
                 output = subprocess.check_output(

--- a/cdist/exec/util.py
+++ b/cdist/exec/util.py
@@ -24,10 +24,12 @@ import itertools
 import os
 import subprocess
 
+import cdist
+
 from collections import OrderedDict
 from tempfile import TemporaryFile
 
-import cdist
+from cdist.util import shquot
 
 
 # IMPORTANT:
@@ -175,14 +177,16 @@ if hasattr(subprocess, 'DEVNULL'):
     def log_std_fd(log, command, stdfd, prefix):
         if stdfd is not None and stdfd != subprocess.DEVNULL:
             stdfd.seek(0, 0)
-            log.trace("Command: {}; {}: {}".format(command, prefix,
-                                                   stdfd.read().decode()))
+            log.trace("Command: %s; %s: %s",
+                      shquot.join(command),
+                      prefix, stdfd.read().decode())
 else:
     def log_std_fd(log, command, stdfd, prefix):
         if stdfd is not None and not isinstance(stdfd, int):
             stdfd.seek(0, 0)
-            log.trace("Command: {}; {}: {}".format(command, prefix,
-                                                   stdfd.read().decode()))
+            log.trace("Command: %s; %s: %s",
+                      shquot.join(command),
+                      prefix, stdfd.read().decode())
 
 
 def resolve_conf_dirs(*args):

--- a/cdist/util/shquot.py
+++ b/cdist/util/shquot.py
@@ -25,7 +25,7 @@ _needs_shell_quoting = re.compile(r"[^\w@%+=:,./-]", re.ASCII).search
 
 
 def join(cmd_args):
-    return " ".join(quote(a) for a in cmd_args)
+    return " ".join(map(quote, cmd_args))
 
 
 def quote(s):


### PR DESCRIPTION
This makes commands easier to read than "stringified lists" while keeping the information about separate arguments (clearer representation of arguments with spaces, unlike the plain space concatenated variant).