### PR TITLE
Disable colours for dumb terminals

### DIFF
--- a/cdist/test/settings/__init__.py
+++ b/cdist/test/settings/__init__.py
@@ -395,6 +395,24 @@ class ColouredOutputSettingTestCase(test.CdistTestCase):
         self.coloured_output_setting = "auto"
         self.assertEqual(self.coloured_output_setting, False)
 
+    @test.patch("sys.stdout.isatty")
+    @test.patch.dict("os.environ")
+    def test_auto_checks_for_dumb_terminals(self, stdout_isatty):
+        stdout_isatty.return_value = True
+        if "NO_COLOR" in os.environ:
+            del os.environ["NO_COLOR"]
+        if "TERM" in os.environ:
+            del os.environ["TERM"]
+
+        # colours should be enabled
+        self.coloured_output_setting = "auto"
+        self.assertEqual(self.coloured_output_setting, True)
+
+        # with TERM=dumb, colours should be disabled
+        os.environ["TERM"] = "dumb"
+        self.coloured_output_setting = "auto"
+        self.assertEqual(self.coloured_output_setting, False)
+
     def test_invalid_choices(self):
         self.coloured_output_setting = "always"
 

--- a/skonfig/settings.py
+++ b/skonfig/settings.py
@@ -178,7 +178,10 @@ class coloured_output_setting(choice_setting):
             return False
         elif value == "auto":
             import sys
-            return "NO_COLOR" not in os.environ and sys.stdout.isatty()
+            return all((
+                ("NO_COLOR" not in os.environ),
+                (os.environ.get("TERM") != "dumb"),
+                sys.stdout.isatty()))
 
 
 class loglevel_setting(any_setting):


### PR DESCRIPTION
When colours are set to auto, I think we should not enable them when the `TERM` environment variable signals a dumb terminal.
I don't think we can rely on a dumb terminal to handle the escape sequences correctly.