### PR TITLE
Mock `os.environ` for test cases modifying the environment

### DIFF
--- a/cdist/test/__init__.py
+++ b/cdist/test/__init__.py
@@ -43,6 +43,7 @@ global_fixtures_dir = os.path.abspath(
 class CdistTestCase(unittest.TestCase):
     remote_exec = os.path.join(global_fixtures_dir, "remote", "exec")
 
+    # host, hostname, fqdn
     target_host = ('cdisttesthost', 'cdisttesthost', 'cdisttesthost')
 
     def mkdtemp(self, **kwargs):

--- a/cdist/test/config/__init__.py
+++ b/cdist/test/config/__init__.py
@@ -59,12 +59,10 @@ class CdistObjectErrorContext:
                 raise exc_value.original_error
 
 
+@test.patch.dict("os.environ")
 class ConfigRunTestCase(test.CdistTestCase):
 
     def setUp(self):
-        # change env for context
-        self.orig_environ = os.environ
-        os.environ = os.environ.copy()
         self.temp_dir = self.mkdtemp()
 
         self.settings = skonfig.settings.SettingsContainer()
@@ -117,7 +115,6 @@ class ConfigRunTestCase(test.CdistTestCase):
             o.requirements = []
             o.state = ""
 
-        os.environ = self.orig_environ
         shutil.rmtree(self.temp_dir)
 
     def assertRaisesCdistObjectError(self, original_error, callable_obj):

--- a/cdist/test/manifest/__init__.py
+++ b/cdist/test/manifest/__init__.py
@@ -46,8 +46,6 @@ conf_dir = os.path.join(fixtures, 'conf')
 class ManifestTestCase(test.CdistTestCase):
 
     def setUp(self):
-        self.orig_environ = os.environ
-        os.environ = os.environ.copy()
         self.temp_dir = self.mkdtemp()
 
         out_path = self.temp_dir
@@ -69,9 +67,9 @@ class ManifestTestCase(test.CdistTestCase):
         self.log = logging.getLogger(self.target_host[0])
 
     def tearDown(self):
-        os.environ = self.orig_environ
         shutil.rmtree(self.temp_dir)
 
+    @test.patch.dict("os.environ")
     def test_initial_manifest_environment(self):
         initial_manifest = os.path.join(self.local.manifest_path,
                                         "dump_environment")
@@ -108,6 +106,7 @@ class ManifestTestCase(test.CdistTestCase):
         self.assertEqual(output_dict['__cdist_log_level_name'], 'VERBOSE')
         self.log.setLevel(old_loglevel)
 
+    @test.patch.dict("os.environ")
     def test_type_manifest_environment(self):
         cdist_type = core.CdistType(self.local.type_path, '__dump_environment')
         cdist_object = core.CdistObject(cdist_type, self.local.object_path,

--- a/cdist/test/settings/__init__.py
+++ b/cdist/test/settings/__init__.py
@@ -368,6 +368,7 @@ class ColouredOutputSettingTestCase(test.CdistTestCase):
             self.assertEqual(self.coloured_output_setting, b)
 
     @test.patch('sys.stdout.isatty')
+    @test.patch.dict("os.environ")
     def test_auto_respects_no_color(self, stdout_isatty):
         stdout_isatty.return_value = True
 
@@ -378,6 +379,7 @@ class ColouredOutputSettingTestCase(test.CdistTestCase):
         self.assertEqual(self.coloured_output_setting, False)
 
     @test.patch('sys.stdout.isatty')
+    @test.patch.dict("os.environ")
     def test_auto_checks_isatty(self, stdout_isatty):
         self.coloured_output_setting = "always"
         self.assertEqual(self.coloured_output_setting, True)


### PR DESCRIPTION
Let's mock `os.environ` for all test cases which require modifications to the environment.

Doing this I already discovered a bug in the `emulator` test suite where the stdin test depended on modifications of the environment done by other tests in the same module.