### PR TITLE
Set POSIX locale (C) for all scripts (explorer, manifest, code)

### DIFF
--- a/skonfig/core/code.py
+++ b/skonfig/core/code.py
@@ -102,7 +102,9 @@ class Code:
         self.target_host = target_host
         self.local = local
         self.remote = remote
-        self.env = {
+        self.env_local = {
+            'LANG': 'C',
+            'LC_ALL': 'C',
             '__target_host': self.target_host[0],
             '__target_hostname': self.target_host[1],
             '__target_fqdn': self.target_host[2],
@@ -116,7 +118,7 @@ class Code:
         }
 
         if dry_run:
-            self.env['__cdist_dry_run'] = '1'
+            self.env_local['__cdist_dry_run'] = '1'
 
     def _run_gencode(self, cdist_object, which):
         cdist_type = cdist_object.cdist_type
@@ -140,7 +142,7 @@ class Code:
         code = ""
         for script in scripts:
             env = os.environ.copy()
-            env.update(self.env)
+            env.update(self.env_local)
             env.update({
                 '__type': cdist_object.cdist_type.absolute_path,
                 '__object': cdist_object.absolute_path,
@@ -197,7 +199,7 @@ class Code:
         # Put some env vars, to allow read only access to the parameters
         # over $__object
         env = os.environ.copy()
-        env.update(self.env)
+        env.update(self.env_local)
         env.update({
             '__object': cdist_object.absolute_path,
             '__object_id': cdist_object.object_id,
@@ -209,6 +211,8 @@ class Code:
         # Put some env vars, to allow read only access to the parameters
         # over $__object which is already on the target
         env = {
+            'LANG': 'C',
+            'LC_ALL': 'C',
             '__object': os.path.join(self.remote.object_path,
                                      cdist_object.path),
             '__object_id': cdist_object.object_id,

--- a/skonfig/core/code.py
+++ b/skonfig/core/code.py
@@ -139,20 +139,21 @@ class Code:
             scripts = [script]
         else:
             return
-        code = ""
-        for script in scripts:
-            env = os.environ.copy()
-            env.update(self.env_local)
-            env.update({
-                '__type': cdist_object.cdist_type.absolute_path,
-                '__object': cdist_object.absolute_path,
-                '__object_id': cdist_object.object_id,
-                '__object_name': cdist_object.name,
+        env = os.environ.copy()
+        env.update(self.env_local)
+        env.update({
+            "__type": cdist_object.cdist_type.absolute_path,
+            "__object": cdist_object.absolute_path,
+            "__object_id": cdist_object.object_id,
+            "__object_name": cdist_object.name,
             })
-            message_prefix = cdist_object.name
-            with get_std_fd(
-                    cdist_object.stderr_path,
-                    "gencode-%s" % (which)) as stderr:
+        message_prefix = cdist_object.name
+
+        code = ""
+        with get_std_fd(
+                cdist_object.stderr_path,
+                "gencode-%s" % (which)) as stderr:
+            for script in scripts:
                 code += self.local.run_script(
                     script,
                     env=env,

--- a/skonfig/core/explorer.py
+++ b/skonfig/core/explorer.py
@@ -2,7 +2,7 @@
 #
 # 2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
-# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -75,6 +75,8 @@ class Explorer:
         self.local = local
         self.remote = remote
         self.env = {
+            'LANG': 'C',
+            'LC_ALL': 'C',
             '__target_host': self.target_host[0],
             '__target_hostname': self.target_host[1],
             '__target_fqdn': self.target_host[2],

--- a/skonfig/core/manifest.py
+++ b/skonfig/core/manifest.py
@@ -2,6 +2,7 @@
 #
 # 2011-2013 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
+# 2020,2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -110,6 +111,8 @@ class Manifest:
         self._open_logger()
 
         self.env = {
+            'LANG': 'C',
+            'LC_ALL': 'C',
             'PATH': "{}:{}".format(self.local.bin_path, os.environ['PATH']),
             # for use in type emulator
             '__cdist_type_base_path': self.local.type_path,

--- a/skonfig/core/manifest.py
+++ b/skonfig/core/manifest.py
@@ -2,7 +2,10 @@
 #
 # 2011-2013 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
+# 2013 Arkaitz Jimenez (arkaitzj at gmail.com)
+# 2016-2021 Darko Poljak (darko.poljak at gmail.com)
 # 2020,2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2024 Ander Punnar (ander at kvlt.ee)
 #
 # This file is part of skonfig.
 #

--- a/skonfig/core/manifest.py
+++ b/skonfig/core/manifest.py
@@ -215,12 +215,12 @@ class Manifest:
             return
         message_prefix = cdist_object.name
         which = 'manifest'
-        for type_manifest in type_manifests:
-            self.log.verbose("Running type manifest %s for object %s",
-                             type_manifest, cdist_object.name)
 
-            with get_std_fd(cdist_object.stdout_path, which) as stdout, \
-                 get_std_fd(cdist_object.stderr_path, which) as stderr:
+        with get_std_fd(cdist_object.stdout_path, which) as stdout, \
+             get_std_fd(cdist_object.stderr_path, which) as stderr:
+            for type_manifest in type_manifests:
+                self.log.verbose("Running type manifest %s for object %s",
+                                 type_manifest, cdist_object.name)
                 self.local.run_script(
                     type_manifest,
                     env=self.env_type_manifest(cdist_object),

--- a/tests/code/fixtures/conf/type/__dump_locale/gencode-local
+++ b/tests/code/fixtures/conf/type/__dump_locale/gencode-local
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# dump gencode-time values as comments
+locale | sed -e 's/^/# /'
+
+# run locale on code execution
+echo 'locale'

--- a/tests/code/fixtures/conf/type/__dump_locale/gencode-remote
+++ b/tests/code/fixtures/conf/type/__dump_locale/gencode-remote
@@ -1,0 +1,1 @@
+gencode-local

--- a/tests/explorer/__init__.py
+++ b/tests/explorer/__init__.py
@@ -2,6 +2,7 @@
 #
 # 2010-2011 Steven Armstrong (steven-cdist at armstrong.cc)
 # 2011-2013 Nico Schottelius (nico-cdist at schottelius.org)
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -22,6 +23,7 @@
 import glob
 import logging
 import os
+import shlex
 import shutil
 
 import skonfig
@@ -248,6 +250,22 @@ class ExplorerClassTestCase(test.SkonfigTestCase):
             }
 
         self.assertEqual(output_expected, output_is)
+
+    def test_explorer_locale(self):
+        cdist_type = core.CdistType(self.local.type_path, "__dump_locale")
+        cdist_object = core.CdistObject(cdist_type, self.local.object_path,
+                                        self.local.object_marker_name,
+                                        "whatever")
+        self.explorer.transfer_type_explorers(cdist_type)
+        output = self.explorer.run_type_explorer("dump", cdist_object)
+
+        for line in output.splitlines(keepends=False):
+            (k, v) = line.split("=", 2)
+
+            if "LANG" == k or k.startswith("LC_"):
+                self.assertEqual(
+                    "C", shlex.split(v)[0],
+                    "Environment variable %s is expected to be %s" % (k, "C"))
 
 
 if __name__ == '__main__':

--- a/tests/explorer/fixtures/conf/type/__dump_locale/explorer/dump
+++ b/tests/explorer/fixtures/conf/type/__dump_locale/explorer/dump
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+locale

--- a/tests/fixtures/remote/exec
+++ b/tests/fixtures/remote/exec
@@ -2,20 +2,20 @@
 #
 # 2012 Nico Schottelius (nico-cdist schottelius.org)
 #
-# This file is part of cdist.
+# This file is part of skonfig.
 #
-# cdist is free software: you can redistribute it and/or modify
+# skonfig is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cdist is distributed in the hope that it will be useful,
+# skonfig is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+# along with skonfig. If not, see <http://www.gnu.org/licenses/>.
 #
 #
 

--- a/tests/manifest/__init__.py
+++ b/tests/manifest/__init__.py
@@ -79,7 +79,7 @@ class ManifestTestCase(test.SkonfigTestCase):
         os.close(handle)
         os.environ['__cdist_test_out'] = output_file
         old_loglevel = logging.root.getEffectiveLevel()
-        self.log.setLevel(logging.VERBOSE)
+        self.log.setLevel(logging.OFF)
         manifest = skonfig.core.manifest.Manifest(self.target_host, self.local)
         manifest.run_initial_manifest(initial_manifest)
 
@@ -101,9 +101,8 @@ class ManifestTestCase(test.SkonfigTestCase):
         self.assertEqual(output_is['__manifest'], self.local.manifest_path)
         self.assertEqual(output_is['__files'], self.local.files_path)
         self.assertEqual(output_is['__target_host_tags'], '')
-        self.assertEqual(output_is['__cdist_log_level'],
-                         str(logging.VERBOSE))
-        self.assertEqual(output_is['__cdist_log_level_name'], 'VERBOSE')
+        self.assertEqual(output_is['__cdist_log_level'], str(logging.OFF))
+        self.assertEqual(output_is['__cdist_log_level_name'], 'OFF')
 
         self.log.setLevel(old_loglevel)
 
@@ -138,7 +137,7 @@ class ManifestTestCase(test.SkonfigTestCase):
         os.close(handle)
         os.environ['__cdist_test_out'] = output_file
         old_loglevel = self.log.getEffectiveLevel()
-        self.log.setLevel(logging.VERBOSE)
+        self.log.setLevel(logging.OFF)
         manifest = skonfig.core.manifest.Manifest(self.target_host, self.local)
         manifest.run_type_manifest(cdist_object)
 
@@ -163,9 +162,8 @@ class ManifestTestCase(test.SkonfigTestCase):
         self.assertEqual(output_is['__object_name'], cdist_object.name)
         self.assertEqual(output_is['__files'], self.local.files_path)
         self.assertEqual(output_is['__target_host_tags'], '')
-        self.assertEqual(output_is['__cdist_log_level'],
-                         str(logging.VERBOSE))
-        self.assertEqual(output_is['__cdist_log_level_name'], 'VERBOSE')
+        self.assertEqual(output_is['__cdist_log_level'], str(logging.OFF))
+        self.assertEqual(output_is['__cdist_log_level_name'], 'OFF')
         self.log.setLevel(old_loglevel)
 
     @test.patch.dict("os.environ")

--- a/tests/manifest/fixtures/conf/manifest/locale
+++ b/tests/manifest/fixtures/conf/manifest/locale
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+locale >"${__cdist_test_out:?}"

--- a/tests/manifest/fixtures/conf/type/__locale/manifest
+++ b/tests/manifest/fixtures/conf/type/__locale/manifest
@@ -1,0 +1,1 @@
+../../manifest/locale


### PR DESCRIPTION
This PR is a follow-up to skonfig/base#133.

The `LANG` and `LC_ALL` environment variables are not set to `C` for all explorers, manifests, gencode and code scripts.
I updated the tests accordingly.

Also a small change for "multi-part" manifests/gencode: I reduced the loop to cover only the execution of the scripts.
The environment and stdout/stderr file descriptors can be handled outside of the loop because it doesn't change for the different parts. 