### PR TITLE
Create SSH control socket and messages files inside single directory

### DIFF
--- a/skonfig/exec/local.py
+++ b/skonfig/exec/local.py
@@ -57,7 +57,8 @@ class Local:
                  exec_path=sys.argv[0]):
         self.target_host = target_host
         self.hostdir = os.path.basename(base_root_path.rstrip("/"))
-        self.base_path = os.path.join(base_root_path, "data")
+
+        self.base_path = os.path.join(base_root_path, "work")
         self.temp_dir = os.path.join(base_root_path, "tmp")
 
         self.exec_path = exec_path

--- a/skonfig/exec/local.py
+++ b/skonfig/exec/local.py
@@ -58,6 +58,7 @@ class Local:
         self.target_host = target_host
         self.hostdir = os.path.basename(base_root_path.rstrip("/"))
         self.base_path = os.path.join(base_root_path, "data")
+        self.temp_dir = os.path.join(base_root_path, "tmp")
 
         self.exec_path = exec_path
         self.custom_initial_manifest = initial_manifest
@@ -67,6 +68,8 @@ class Local:
         self._init_permissions()
         self.mkdir(self.base_path)
         self._init_cache_dir(None)
+        self.mkdir(self.temp_dir)
+
         self._init_paths()
         self._init_object_marker()
         self._init_conf_dirs()
@@ -186,7 +189,7 @@ class Local:
 
         if message_prefix:
             message = skonfig.message.Message(
-                message_prefix, self.messages_path)
+                message_prefix, self.messages_path, temp_dir=self.temp_dir)
             env.update(message.env)
 
         self.log.trace("Local run: %s", shquot.join(command))

--- a/skonfig/exec/local.py
+++ b/skonfig/exec/local.py
@@ -65,36 +65,23 @@ class Local:
         self.custom_initial_manifest = initial_manifest
         self.settings = settings
 
-        self._init_log()
-        self._init_permissions()
-        self.mkdir(self.base_path)
-        self._init_cache_dir(None)
-        self.mkdir(self.temp_dir)
+        from skonfig.settings import get_cache_dir
+        self.cache_path = get_cache_dir()
 
-        self._init_paths()
-        self._init_object_marker()
-        self._init_conf_dirs()
+        self.conf_dirs = util.resolve_conf_dirs(self.settings.conf_dir)
 
-    def _init_log(self):
-        self.log = skonfig.logging.getLogger(self.target_host[0])
+        self.object_marker_file = os.path.join(self.base_path, "object_marker")
 
-    # logger is not pickable, so remove it when we pickle
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        if 'log' in state:
-            del state['log']
-        return state
+        # does not need to be secure - just randomly different from .skonfig
+        self.object_marker_name = tempfile.mktemp(prefix=".skonfig-", dir="")
 
-    # recreate logger when we unpickle
-    def __setstate__(self, state):
-        self.__dict__.update(state)
         self._init_log()
 
-    def _init_permissions(self):
         # Setup file permissions using umask
         os.umask(0o077)
+        self.mkdir(self.base_path)
+        self.mkdir(self.temp_dir)
 
-    def _init_paths(self):
         # Depending on out_path
         self.bin_path = os.path.join(self.base_path, "bin")
         self.conf_path = os.path.join(self.base_path, "conf")
@@ -114,16 +101,22 @@ class Local:
 
         self.type_path = os.path.join(self.conf_path, "type")
 
-    def _init_object_marker(self):
-        self.object_marker_file = os.path.join(self.base_path, "object_marker")
+    def _init_log(self):
+        self.log = skonfig.logging.getLogger(self.target_host[0])
 
-        # Does not need to be secure - just randomly different from .skonfig
-        self.object_marker_name = tempfile.mktemp(prefix=".skonfig-", dir='')
+    # logger is not pickable, so remove it when we pickle
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if 'log' in state:
+            del state['log']
+        return state
 
-    def _init_conf_dirs(self, *args):
-        self.conf_dirs = util.resolve_conf_dirs(self.settings.conf_dir, *args)
+    # recreate logger when we unpickle
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._init_log()
 
-    def _init_directories(self):
+    def create_files_dirs(self):
         self.mkdir(self.conf_path)
         self.mkdir(self.global_explorer_out_path)
         self.mkdir(self.object_path)
@@ -132,23 +125,17 @@ class Local:
         self.mkdir(self.stdout_base_path)
         self.mkdir(self.stderr_base_path)
 
-    def create_files_dirs(self):
-        self._init_directories()
         self._create_conf_path_and_link_conf_dirs()
-        self._create_messages()
+
+        # create empty global messages file
+        with open(self.messages_path, "w"):
+            pass
+
         self._link_types_for_emulator()
-        self._setup_object_marker_file()
 
-    def _setup_object_marker_file(self):
-        with open(self.object_marker_file, 'w') as fd:
-            fd.write("{}\n".format(self.object_marker_name))
-
-        self.log.trace("Object marker %s saved in %s",
-                       self.object_marker_name, self.object_marker_file)
-
-    def _init_cache_dir(self, cache_dir):
-        from skonfig.settings import get_cache_dir
-        self.cache_path = get_cache_dir()
+        # create object marker file
+        with open(self.object_marker_file, "w") as f:
+            f.write((self.object_marker_name + "\n"))
 
     def rmdir(self, path):
         """Remove directory on the local side."""
@@ -252,25 +239,16 @@ class Local:
         elif matchobj.group(2) == '%N':
             repl = self.target_host[0]
 
-        return matchobj.group(1) + repl
+        return (matchobj.group(1) + repl)
 
     def _cache_subpath(self, start_time=time.time(), path_format=None):
+        cache_subpath = ""
         if path_format:
-            repl_func = self._cache_subpath_repl
-            cache_subpath = re.sub(r'([^%]|^)(%h|%P|%N)', repl_func,
-                                   path_format)
+            cache_subpath = re.sub(
+                r'([^%]|^)(%h|%P|%N)', self._cache_subpath_repl, path_format)
             dt = datetime.datetime.fromtimestamp(start_time)
             cache_subpath = dt.strftime(cache_subpath)
-        else:
-            cache_subpath = self.hostdir
-
-        i = 0
-        while i < len(cache_subpath) and cache_subpath[i] == os.sep:
-            i += 1
-        cache_subpath = cache_subpath[i:]
-        if not cache_subpath:
-            cache_subpath = self.hostdir
-        return cache_subpath
+        return cache_subpath.lstrip(os.sep) or self.hostdir
 
     def save_cache(self, start_time=time.time()):
         self.log.trace("cache subpath pattern: %s",
@@ -302,11 +280,6 @@ class Local:
         host_cache_path = os.path.join(destination, "target_host")
         with open(host_cache_path, 'w') as hostf:
             print(self.target_host[0], file=hostf)
-
-    def _create_messages(self):
-        """Create empty messages"""
-        with open(self.messages_path, "w"):
-            pass
 
     def _create_conf_path_and_link_conf_dirs(self):
         # Create destination directories

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -49,6 +49,11 @@ class SkonfigTestCase(unittest.TestCase):
     def mkstemp(self, **kwargs):
         return tempfile.mkstemp(prefix='tmp.test.', **kwargs)
 
+    if sys.version_info[:2] < (3, 14):
+        from .backports.assertSubstring import (
+            assertStartsWith, assertNotStartsWith,
+            assertEndsWith, assertNotEndsWith)
+
 
 if sys.version_info[:2] < (3, 4):
     from .backports.assertLogs import _AssertLogsContext

--- a/tests/backports/assertSubstring.py
+++ b/tests/backports/assertSubstring.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# backported from Python stdlib by
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig.
+#
+# skonfig is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig. If not, see <http://www.gnu.org/licenses/>.
+#
+# backport of unittest/case.py's assert(Not)StartsWith(),
+# assert(Not)EndsWith().
+#
+
+from unittest.util import safe_repr
+
+def _tail_type_check(self, s, tails, msg):
+    if not isinstance(tails, tuple):
+        tails = (tails,)
+    for tail in tails:
+        if isinstance(tail, str):
+            if not isinstance(s, str):
+                self.fail(self._formatMessage(msg,
+                        'Expected str, not %s' % (type(s).__name__)))
+        elif isinstance(tail, (bytes, bytearray)):
+            if not isinstance(s, (bytes, bytearray)):
+                self.fail(self._formatMessage(msg,
+                        'Expected bytes, not %s' % (type(s).__name__)))
+
+def assertStartsWith(self, s, prefix, msg=None):
+    try:
+        if s.startswith(prefix):
+            return
+    except (AttributeError, TypeError):
+        self._tail_type_check(s, prefix, msg)
+        raise
+    a = safe_repr(s, short=True)
+    b = safe_repr(prefix)
+    if isinstance(prefix, tuple):
+        standardMsg = "%s doesn't start with any of %s" % (a, b)
+    else:
+        standardMsg = "%s doesn't start with %s" % (a, b)
+    self.fail(self._formatMessage(msg, standardMsg))
+
+def assertNotStartsWith(self, s, prefix, msg=None):
+    try:
+        if not s.startswith(prefix):
+            return
+    except (AttributeError, TypeError):
+        self._tail_type_check(s, prefix, msg)
+        raise
+    if isinstance(prefix, tuple):
+        for x in prefix:
+            if s.startswith(x):
+                prefix = x
+                break
+    a = safe_repr(s, short=True)
+    b = safe_repr(prefix)
+    self.fail(self._formatMessage(msg, "%s starts with %s" % (a, b)))
+
+def assertEndsWith(self, s, suffix, msg=None):
+    try:
+        if s.endswith(suffix):
+            return
+    except (AttributeError, TypeError):
+        self._tail_type_check(s, suffix, msg)
+        raise
+    a = safe_repr(s, short=True)
+    b = safe_repr(suffix)
+    if isinstance(suffix, tuple):
+        standardMsg = "%s doesn't end with any of %s" % (a, b)
+    else:
+        standardMsg = "%s doesn't end with %s" % (a, b)
+    self.fail(self._formatMessage(msg, standardMsg))
+
+def assertNotEndsWith(self, s, suffix, msg=None):
+    try:
+        if not s.endswith(suffix):
+            return
+    except (AttributeError, TypeError):
+        self._tail_type_check(s, suffix, msg)
+        raise
+    if isinstance(suffix, tuple):
+        for x in suffix:
+            if s.endswith(x):
+                suffix = x
+                break
+    a = safe_repr(s, short=True)
+    b = safe_repr(suffix)
+    self.fail(self._formatMessage(msg, "%s ends with %s" % (a, b)))

--- a/tests/code/__init__.py
+++ b/tests/code/__init__.py
@@ -97,7 +97,7 @@ class CodeTestCase(test.SkonfigTestCase):
         regex = re.compile(r"^echo (['\"]?)(.*?): *(.*)\1")
         output_is = dict(
             regex.match(line).groups()[1:]
-            for line in filter(None, output_string.splitlines(keepends=False)))
+            for line in filter(None, output_string.splitlines(False)))
 
         output_expected = {
             "__target_host": self.local.target_host[0],
@@ -119,7 +119,7 @@ class CodeTestCase(test.SkonfigTestCase):
     def test_run_gencode_local_locale(self):
         output_string = self.code.run_gencode_local(self.cdist_object_locale)
 
-        for line in output_string.splitlines(keepends=False):
+        for line in output_string.splitlines(False):
             if not line.startswith("#"):
                 continue
 
@@ -136,7 +136,7 @@ class CodeTestCase(test.SkonfigTestCase):
         regex = re.compile(r"^echo (['\"]?)(.*?): *(.*)\1")
         output_is = dict(
             regex.match(line).groups()[1:]
-            for line in filter(None, output_string.splitlines(keepends=False)))
+            for line in filter(None, output_string.splitlines(False)))
 
         output_expected = {
             "__target_host": self.local.target_host[0],
@@ -158,7 +158,7 @@ class CodeTestCase(test.SkonfigTestCase):
     def test_run_gencode_remote_locale(self):
         output_string = self.code.run_gencode_remote(self.cdist_object_locale)
 
-        for line in output_string.splitlines(keepends=False):
+        for line in output_string.splitlines(False):
             if not line.startswith("#"):
                 continue
 
@@ -188,7 +188,7 @@ class CodeTestCase(test.SkonfigTestCase):
         with open(code_local_stdout, "rt") as f:
             output_is = dict(
                 line.split(": ", 2)
-                for line in filter(None, f.read().splitlines(keepends=False)))
+                for line in filter(None, f.read().splitlines(False)))
 
         output_expected = {
             "__target_host": self.local.target_host[0],
@@ -217,7 +217,7 @@ class CodeTestCase(test.SkonfigTestCase):
             self.cdist_object_locale.stdout_path, "code-local")
 
         with open(code_local_stdout, "rt") as f:
-            for line in f.read().splitlines(keepends=False):
+            for line in f.read().splitlines(False):
                 (k, v) = line.split("=", 2)
 
                 if "LANG" == k or k.startswith("LC_"):
@@ -237,7 +237,7 @@ class CodeTestCase(test.SkonfigTestCase):
         with open(code_remote_stdout, "rt") as f:
             output_is = dict(
                 line.split(": ", 2)
-                for line in filter(None, f.read().splitlines(keepends=False)))
+                for line in filter(None, f.read().splitlines(False)))
 
         output_expected = {
             "__target_host": self.local.target_host[0],
@@ -267,7 +267,7 @@ class CodeTestCase(test.SkonfigTestCase):
             self.cdist_object_locale.stdout_path, "code-remote")
 
         with open(code_remote_stdout, "rt") as f:
-            for line in f.read().splitlines(keepends=False):
+            for line in f.read().splitlines(False):
                 (k, v) = line.split("=", 2)
 
                 if "LANG" == k or k.startswith("LC_"):

--- a/tests/exec/local.py
+++ b/tests/exec/local.py
@@ -53,7 +53,7 @@ class LocalTestCase(test.SkonfigTestCase):
         self.out_parent_path = self.temp_dir
         self.hostdir = skonfig.util.str_hash(target_host[0])
         self.host_base_path = os.path.join(self.out_parent_path, self.hostdir)
-        out_path = os.path.join(self.host_base_path, "data")
+        out_path = os.path.join(self.host_base_path, "work")
 
         self.settings = skonfig.settings.SettingsContainer()
         self.settings.conf_dir = conf_dirs

--- a/tests/explorer/__init__.py
+++ b/tests/explorer/__init__.py
@@ -259,7 +259,7 @@ class ExplorerClassTestCase(test.SkonfigTestCase):
         self.explorer.transfer_type_explorers(cdist_type)
         output = self.explorer.run_type_explorer("dump", cdist_object)
 
-        for line in output.splitlines(keepends=False):
+        for line in output.splitlines(False):
             (k, v) = line.split("=", 2)
 
             if "LANG" == k or k.startswith("LC_"):

--- a/tests/manifest/__init__.py
+++ b/tests/manifest/__init__.py
@@ -86,7 +86,7 @@ class ManifestTestCase(test.SkonfigTestCase):
         with open(output_file, "r") as f:
             output_is = dict(
                 line.split(': ', 2)
-                for line in filter(None, f.read().splitlines(keepends=False)))
+                for line in filter(None, f.read().splitlines(False)))
 
         self.assertTrue(output_is['PATH'].startswith(self.local.bin_path))
         self.assertEqual(output_is['__target_host'],
@@ -116,7 +116,7 @@ class ManifestTestCase(test.SkonfigTestCase):
         manifest.run_initial_manifest(initial_manifest)
 
         with os.fdopen(output_fd) as f:
-            lines = filter(None, f.read().splitlines(keepends=False))
+            lines = filter(None, f.read().splitlines(False))
 
         for line in lines:
             (k, v) = line.split("=", 2)
@@ -144,7 +144,7 @@ class ManifestTestCase(test.SkonfigTestCase):
         with open(output_file, "r") as f:
             output_is = dict(
                 line.split(': ', 2)
-                for line in filter(None, f.read().splitlines(keepends=False)))
+                for line in filter(None, f.read().splitlines(False)))
 
         self.assertTrue(output_is['PATH'].startswith(self.local.bin_path))
         self.assertEqual(output_is['__target_host'],
@@ -180,7 +180,7 @@ class ManifestTestCase(test.SkonfigTestCase):
         manifest.run_type_manifest(cdist_object)
 
         with os.fdopen(output_fd) as f:
-            lines = filter(None, f.read().splitlines(keepends=False))
+            lines = filter(None, f.read().splitlines(False))
 
         for line in lines:
             (k, v) = line.split("=", 2)


### PR DESCRIPTION
The SSH control socket and temporary `__messages_{in,out}` were not created in the single temporary directory like everything else.
I added a `tmp` directory for these cases and renamed the `data` directory to `work`.

The only thing (I could find) which is still not in the single directory is the temporary copy of the stdin initial manifest. The reason for this is that the copy is taken very early, before the other directories have been created.
Of course, we could move this around to make it work, but I was thinking whether we even need this copy as a file. Couldn't we just pass stdin on to the shell directly? :thinking:

And like always, while at it, I also cleaned up some other minor stuff I disliked and fixed tests for Python 3.2.