### PR TITLE
setup.py: Auto add missing sub-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -292,7 +292,7 @@ ManPages.update_data_files(data_files)
 setup(
     name="skonfig",
     license="GPL-3.0-or-later",
-    packages=["skonfig"],
+    package_dir={"skonfig": "skonfig"},
     scripts=glob.glob(os.path.join(os.path.dirname(__file__), "bin", "*")),
     version=__import__("skonfig").__version__,
     description="system configuration framework",


### PR DESCRIPTION
In the `setup.py` `build` and `sdist`/`bdist` tarballs all modules located in sub-packages of `skonfig` were missing due to only the `skonfig` package being included. Use `package_dir` instead to let setuptools include all sub-packages as well.