### PR TITLE
CI: Update runners

### DIFF
--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -23,7 +23,8 @@ jobs:
           - pypy-3.11
           - graalpy-22.3.1
           - graalpy-23.1.2
-          - graalpy-24.1.2
+          - graalpy-24.2.2
+          - graalpy-25.0.0
         exclude:
           - {os: "macos-14", python-version: "pypy-3.6"}
           - {os: "macos-14", python-version: "pypy-3.7"}

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13
+          - macos-14  # ARM
+          - macos-15-intel
         python-version:
           - pypy-3.6
           - pypy-3.7
@@ -23,9 +24,9 @@ jobs:
           - graalpy-22.3.1
           - graalpy-23.1.2
           - graalpy-24.1.2
-        include:
-          - {os: "macos-13", python-version: "3.6"}
-          - {os: "macos-13", python-version: "3.7"}
+        exclude:
+          - {os: "macos-14", python-version: "pypy-3.6"}
+          - {os: "macos-14", python-version: "pypy-3.7"}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -23,7 +23,8 @@ jobs:
           - pypy-3.11
           - graalpy-22.3.1
           - graalpy-23.1.2
-          - graalpy-24.1.2
+          - graalpy-24.2.2
+          - graalpy-25.0.0
         exclude:
           - {os: "macos-14", python-version: "pypy-3.6"}
           - {os: "macos-14", python-version: "pypy-3.7"}

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13
+          - macos-14  # ARM
+          - macos-15-intel
         python-version:
           - pypy-3.6
           - pypy-3.7
@@ -23,9 +24,9 @@ jobs:
           - graalpy-22.3.1
           - graalpy-23.1.2
           - graalpy-24.1.2
-        include:
-          - {os: "macos-13", python-version: "3.6"}
-          - {os: "macos-13", python-version: "3.7"}
+        exclude:
+          - {os: "macos-14", python-version: "pypy-3.6"}
+          - {os: "macos-14", python-version: "pypy-3.7"}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code


### PR DESCRIPTION
GitHub is phasing out the macOS 13 runners.

And GraalPy was released in version 25.0.0 recently.